### PR TITLE
Added Logic to post welcome message only for new contributors only 

### DIFF
--- a/lib/autoresponder-plugin.js
+++ b/lib/autoresponder-plugin.js
@@ -17,6 +17,28 @@ module.exports = (robot) => {
       return
     }
 
+    const response = await context.github.issues.listForRepo(context.repo({
+      state: 'all',
+      creator: context.payload.pull_request.user.login
+    }));
+
+    const countPR = response.data.filter(data => data.pull_request);
+    if (countPR.length === 1) {
+      const template = await templates.find(context, 'PR_NEW_REPLY_TEMPLATE')
+      if (template === null || template === '') return
+      const body = Mustache.render(template, vars.generate(context))
+      return context.github.issues.createComment(context.issue({body: body}))
+    }
+  })
+
+  robot.on('pull_request.opened', async context => {
+    const repo = context.repo()
+    const repoAuthz = await robot.checkRepoAuthz(repo.owner, repo.repo)
+    if (!repoAuthz) {
+      robot.log.debug('Ignore unauthorized repo: ' + repo.owner + '/' + repo.repo)
+      return
+    }
+
     const template = await templates.find(context, 'PR_REPLY_TEMPLATE')
     if (template === null || template === '') return
     const body = Mustache.render(template, vars.generate(context))
@@ -33,7 +55,7 @@ module.exports = (robot) => {
 
     const template = await templates.find(context, 'ISSUE_REPLY_TEMPLATE')
     if (template === null || template === '') return
-    const body = Mustache.render(template, vars.generate(context))
-    return context.github.issues.createComment(context.issue({body: body}))
+      const body = Mustache.render(template, vars.generate(context))
+      return context.github.issues.createComment(context.issue({body: body}))
   })
 }


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>
### Description
This pull request ensures that the Welcome message is posted for only new contributors whereas the Review Testing Standards will still be posted for all Pull Requests. So it required to create 2 different PR Reply Templates. Also updated welcome-template a bit as discussed with Eileen. 
Whatever Tests are needed to be added, I will add them as well if any. Please let me know @totten. 