### PR TITLE
PR_REPLY_TEMPLATE - More beautification for regular readers

### DIFF
--- a/config/civicrm/civicrm-core/PR_NEW_REPLY_TEMPLATE.mustache.md
+++ b/config/civicrm/civicrm-core/PR_NEW_REPLY_TEMPLATE.mustache.md
@@ -1,3 +1,0 @@
-(*Standard links*)
-
-* __If this is your first pull-request for CiviCRM__, please read [CONTRIBUTING.md](https://github.com/civicrm/civicrm-core/blob/master/.github/CONTRIBUTING.md) for information about the development and testing processes. Please add or update your details in [contributor-key.yml](https://github.com/civicrm/civicrm-core/blob/master/contributor-key.yml) through a pull request.

--- a/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
+++ b/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
@@ -1,12 +1,22 @@
-Thank you for contributing to CiviCRM! :heart: Here's what's next:
+Thank you for contributing to CiviCRM! ❤️ We will need to test and review the PR. 👷
 
-- If this is your first PR, an admin will greenlight automated testing with the command "add to whitelist".
+<details>
+<summary><strong>Introduction for new contributors</strong></summary>
+
+- If this is your first PR, an admin will greenlight automated testing with the command `ok to test` or `add to whitelist`.
 - A series of tests will automatically run. You can see the results at the bottom of this page (if there are any problems, it will include a link to see what went wrong).
 - A [demo site]({{{ci.browse_test_url}}}) will be built where anyone can try out a version of CiviCRM that includes your changes.
-- If this process needs to be repeated, an admin will issue the command "test this please" to rerun tests and build a new demo site.
+- If this process needs to be repeated, an admin will issue the command `test this please` to rerun tests and build a new demo site.
 - Before this PR can be merged, it [needs to be reviewed](https://docs.civicrm.org/dev/en/latest/core/pr-review/). Please keep in mind that reviewers are volunteers, and their response time can vary from a few hours to a few weeks depending on their availability and their knowledge of this particular part of CiviCRM.
 - A great way to speed up this process is to "trade reviews" with someone - find an open PR that you feel able to review, and leave a comment like "I'm reviewing this now, could you please review mine?" (include a link to yours). You don't have to wait for a response to get started (and you don't have to stop at one!) the more you review, the faster this process goes for everyone :smile:
-- Here are some handy links for reviewers:
-    - [Demo site for this PR]({{{ci.browse_test_url}}})
-    - [Review standards](https://docs.civicrm.org/dev/en/latest/standards/review/)
-    - [Review template](https://civicrm.org/dev/review/template-word.md)
+
+</details>
+
+<details open="open">
+<summary><strong>Quick links for reviewers</strong></summary>
+
+- [➡️ Demo site for this PR]({{{ci.browse_test_url}}})
+- [📖 Review standards](https://docs.civicrm.org/dev/en/latest/standards/review/)
+- [🗒️ Review template](https://civicrm.org/dev/review/template-word.md) (*[brief](https://civicrm.org/dev/review/template-word.md) or [verbose](https://raw.githubusercontent.com/civicrm/civicrm-dev-docs/master/docs/standards/review/template-del-1.0.md)*)
+
+</details>

--- a/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
+++ b/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
@@ -9,6 +9,8 @@ Thank you for contributing to CiviCRM! ❤️ We will need to test and review th
 - If this process needs to be repeated, an admin will issue the command `test this please` to rerun tests and build a new demo site.
 - Before this PR can be merged, it [needs to be reviewed](https://docs.civicrm.org/dev/en/latest/core/pr-review/). Please keep in mind that reviewers are volunteers, and their response time can vary from a few hours to a few weeks depending on their availability and their knowledge of this particular part of CiviCRM.
 - A great way to speed up this process is to "trade reviews" with someone - find an open PR that you feel able to review, and leave a comment like "I'm reviewing this now, could you please review mine?" (include a link to yours). You don't have to wait for a response to get started (and you don't have to stop at one!) the more you review, the faster this process goes for everyone :smile:
+- To ensure that you are credited properly in the final [release notes](https://github.com/civicrm/civicrm-core/blob/master/release-notes.md), please add yourself to [contributor-key.yml](https://github.com/civicrm/civicrm-core/blob/master/contributor-key.yml)
+- For more information about contributing, see [CONTRIBUTING.md](https://github.com/civicrm/civicrm-core/blob/master/.github/CONTRIBUTING.md).
 
 </details>
 

--- a/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
+++ b/config/civicrm/civicrm-core/PR_REPLY_TEMPLATE.mustache.md
@@ -14,7 +14,7 @@ Thank you for contributing to CiviCRM! ❤️ We will need to test and review th
 
 </details>
 
-<details open="open">
+<details>
 <summary><strong>Quick links for reviewers</strong></summary>
 
 - [➡️ Demo site for this PR]({{{ci.browse_test_url}}})


### PR DESCRIPTION
Overview
---------

This is a follow-up to #8. It retains the content and tone, but it improves the layout for folks who read regularly. 

You can see a rendering of this content at https://github.com/totten/githubtest/issues/14.

Changes
---------

* Split into collapsible sections (`<details>`)
    * A wall of text is OK on your first PR, but it gets old if you read multiple PRs.
* Combine `PR_REPLY_TEMPLATE` and `PR_NEW_REPLY_TEMPLATE` into one.
    * Since the intro is collapsible, it's OK to always include the links for `contributor-key.yml` and `CONTRIBUTING.md`. This should be better for 2nd-time/3rd-time contributors (*you can re-find links*) -- and also for bot-developers (*less functionality to consider*)
* Add more icons (emojis) to distinguish links

(*There are some more comments about these in the commit-messages.*)

